### PR TITLE
video's in het fotoboek

### DIFF
--- a/SQL
+++ b/SQL
@@ -9,6 +9,16 @@ CREATE TABLE `fa_photos` (
 	PRIMARY KEY  (`id`),
 	UNIQUE KEY `path` (`path`,`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+CREATE TABLE `fa_videos` (
+	`id` int(11) NOT NULL auto_increment,
+	`name` varchar(64) NOT NULL,
+	`path` varchar(255) NOT NULL,
+	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
+	`cached` set('thumb','320p', '640p','invalidated') NOT NULL,
+	`check_tags` tinyint(1) default '0',
+	PRIMARY KEY  (`id`),
+	UNIQUE KEY `path` (`path`,`name`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 CREATE TABLE `fa_albums` (
 	`id` int(11) NOT NULL auto_increment,
 	`name` varchar(64) NOT NULL,

--- a/SQL
+++ b/SQL
@@ -14,7 +14,7 @@ CREATE TABLE `fa_videos` (
 	`name` varchar(64) NOT NULL,
 	`path` varchar(255) NOT NULL,
 	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
-	`cached` set('thumb','320p', '640p','invalidated') NOT NULL,
+	`cached` set('thumb','360p', '720p','invalidated') NOT NULL,
 	`check_tags` tinyint(1) default '0',
 	PRIMARY KEY  (`id`),
 	UNIQUE KEY `path` (`path`,`name`)

--- a/SQL
+++ b/SQL
@@ -3,19 +3,10 @@ CREATE TABLE `fa_photos` (
 	`name` varchar(64) NOT NULL,
 	`path` varchar(255) NOT NULL,
 	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
-	`cached` set('thumb','large','invalidated') NOT NULL,
+	`cached` set('thumb','large','360p', '720p','invalidated') NOT NULL,
 	`rotation` smallint(6) NOT NULL default '0',
 	`check_tags` tinyint(1) default '0',
-	PRIMARY KEY  (`id`),
-	UNIQUE KEY `path` (`path`,`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-CREATE TABLE `fa_videos` (
-	`id` int(11) NOT NULL auto_increment,
-	`name` varchar(64) NOT NULL,
-	`path` varchar(255) NOT NULL,
-	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
-	`cached` set('thumb','360p', '720p','invalidated') NOT NULL,
-	`check_tags` tinyint(1) default '0',
+	`type` enum('photo','video') NOT NULL default 'photo',
 	PRIMARY KEY  (`id`),
 	UNIQUE KEY `path` (`path`,`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/SQL
+++ b/SQL
@@ -3,7 +3,7 @@ CREATE TABLE `fa_photos` (
 	`name` varchar(64) NOT NULL,
 	`path` varchar(255) NOT NULL,
 	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
-	`cached` set('thumb','large','mp4-360p','webm-360p','mp4-720p','webm-720p','invalidated') NOT NULL,
+	`cached` set('thumb','large','mp4_360p','webm_360p','mp4_720p','webm_720p','invalidated') NOT NULL,
 	`rotation` smallint(6) NOT NULL default '0',
 	`check_tags` tinyint(1) default '0',
 	`type` enum('photo','video') NOT NULL default 'photo',

--- a/SQL
+++ b/SQL
@@ -3,7 +3,7 @@ CREATE TABLE `fa_photos` (
 	`name` varchar(64) NOT NULL,
 	`path` varchar(255) NOT NULL,
 	`visibility` enum('deleted','lost','hidden','leden','world') NOT NULL default 'world',
-	`cached` set('thumb','large','360p', '720p','invalidated') NOT NULL,
+	`cached` set('thumb','large','mp4-360p','webm-360p','mp4-720p','webm-720p','invalidated') NOT NULL,
 	`rotation` smallint(6) NOT NULL default '0',
 	`check_tags` tinyint(1) default '0',
 	`type` enum('photo','video') NOT NULL default 'photo',

--- a/config.php.sample
+++ b/config.php.sample
@@ -5,20 +5,34 @@
 	$domain = 'karpenoktem.nl';
 	$absolute_url_path = '/fotos2/';
 
+	// thumbs layout
 	$thumbs_per_row = 4;
 	$rows_of_thumbs = 2;
 
+	// foto slider
 	$foto_slider = true;
 	$foto_slider_preload = true;
 	$foto_slider_timeout = 5;
 
+	// image resize
 	$imagick = '/usr/local/bin/convert'; // or false to use GD
 	$thumbnail_size = '100x';
 	$large_size = '1024x';
 
+	// video transcoding
+	// ffmpeg command (may have extra options)
+	$ffmpeg = '/usr/local/bin/ffmpeg -loglevel warning';
+	// put preferred codec first
+	// note that mp4 (h264) may have hardware acceleration on certain devices
+	$video_codecs = array('mp4', 'webm');
+	// when changing these don't forget to update the database table!
+	// always put lower resolution first!
+	// and put them in the form of '360p', '480p', '720p', '1080p' etc.
+	$video_resolutions = array('360p', '720p');
+
 	$db_host = 'localhost';
 	$db_user = 'knfotos';
-	$db_db = 'knfotos';
+	$db_db   = 'knfotos';
 	$db_pass = 'abc';
 
 	$mongo_host = 'localhost';

--- a/dbutils.php
+++ b/dbutils.php
@@ -1,6 +1,10 @@
 <?php
 
 	// lock the database/cache for write operations
+	// WARNING: when this is used within a server (non-CLI), the lock will remain
+	// when the PHP script has finished. When run from the command-line, the locks
+	// will be relased by the OS (at least, Linux). See:
+	// http://stackoverflow.com/questions/12651068/release-of-flock-in-case-of-errors
 	function lock_db () {
 		global $cachedir;
 		// provide a locking mechanism to prevent two processes from simultaneously running

--- a/dbutils.php
+++ b/dbutils.php
@@ -1,0 +1,26 @@
+<?php
+
+	// lock the database/cache for write operations
+	function lock_db () {
+		global $cachedir;
+		// provide a locking mechanism to prevent two processes from simultaneously running
+		$fp = fopen ($cachedir .'lockfile', 'w'); // create if necessary
+		if (!$fp) {
+			echo "Could not acquire lock: unable to create lockfile.\n";
+		}
+		if (!flock($fp, LOCK_EX|LOCK_NB)) {
+			echo "Another process is already updating the database/cache.\nIf this isn't true, remove {$cachedir}lockfile.\n";
+			fclose($fp);
+			echo "Exiting.\n";
+			exit;
+		}
+		// $fp is required for unlocking (unlocking may be necessary)
+		return $fp;
+	}
+
+	// unlock again (requires file pointer returned by lock_db)
+	// this isn't really needed when run from the command line
+	function unlock_db ($fp) {
+		flock($fp, LOCK_UN);
+		fclose($fp);
+	}

--- a/foto.php
+++ b/foto.php
@@ -1,51 +1,12 @@
 <?php
-	// this file is almost the same as large.php
 	require('header.php');
-
-	if(!isset($_GET['foto'])) {
-		header('HTTP/1.1 400 Bad Request');
-		showTextAsImage("Missing parameter");
-	}
-	$row = getUnitByFullPath($_GET['foto'], UNIT_PHOTO);
-	if(!$row) {
-		header('HTTP/1.1 404 Not found');
-		showTextAsImage('Photo not found');
-	}
-
-	if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
-		header('HTTP/1.1 403 Access denied');
-		showTextAsImage('Access denied');
-	}
-
-	if(!$mime = $photoExtensions[getext($row['name'])]) {
-		if(!$mime = $videoExtensions[getext($row['name'])]) {
-			showTextAsImage("Unknown extension");
-		}
-	}
+	require('media.php');
 
 	$path = $fotodir . $row['path'] . $row['name'];
 
-	if(!is_file($path)) {
-		header('HTTP/1.1 404 Not found');
-		showTextAsImage("Image not found");
-	}
-
-	// set filename when downloading
+	// send real filename instead of 'foto.php'
 	header('Content-disposition: inline; filename='. $row['name']);
+	output($path);
 
-	if ($row['type'] == 'photo') {
-		header('Content-type: image/'. $mime);
-		header('Pragma: public');
-		header('Cache-Control: public');
-		header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($path)) .' GMT');
-		header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
-		header('Etag: '. md5($path . $fmt));
-		readfile($path);
-	} else {
-		// video
-		// This might not work when X-Sendfile is disabled
-		header('Content-Type: video/'. $mime);
-		header('X-Sendfile: '. $path);
-	}
 	require('footer.php');
 ?>

--- a/foto.php
+++ b/foto.php
@@ -15,7 +15,7 @@
 		showTextAsImage('Access denied');
 	}
 
-	if(!$mime = $extensions[getext($row['name'])]) {
+	if(!$mime = $photoExtensions[getext($row['name'])]) {
 		showTextAsImage("Unknown extension");
 	}
 

--- a/foto.php
+++ b/foto.php
@@ -6,9 +6,7 @@
 
 	$path = $fotodir . $media['path'] . $media['name'];
 
-	// send real filename instead of 'foto.php'
-	header('Content-disposition: inline; filename='. $media['name']);
-	output($path);
+	output($path, $media['name']);
 
 	require('footer.php');
 ?>

--- a/foto.php
+++ b/foto.php
@@ -1,7 +1,9 @@
 <?php
+	// this file is almost the same as large.php
 	require('header.php');
 
 	if(!isset($_GET['foto'])) {
+		header('HTTP/1.1 400 Bad Request');
 		showTextAsImage("Missing parameter");
 	}
 	$row = getUnitByFullPath($_GET['foto'], UNIT_PHOTO);
@@ -16,7 +18,9 @@
 	}
 
 	if(!$mime = $photoExtensions[getext($row['name'])]) {
-		showTextAsImage("Unknown extension");
+		if(!$mime = $videoExtensions[getext($row['name'])]) {
+			showTextAsImage("Unknown extension");
+		}
 	}
 
 	$path = $fotodir . $row['path'] . $row['name'];
@@ -25,12 +29,23 @@
 		header('HTTP/1.1 404 Not found');
 		showTextAsImage("Image not found");
 	}
-	header('Content-type: image/'. $mime);
-	header('Pragma: public');
-	header('Cache-Control: public');
-	header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($path)) .' GMT');
-	header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
-	header('Etag: '. md5($path . $fmt));
-	readfile($path);
+
+	// set filename when downloading
+	header('Content-disposition: inline; filename='. $row['name']);
+
+	if ($row['type'] == 'photo') {
+		header('Content-type: image/'. $mime);
+		header('Pragma: public');
+		header('Cache-Control: public');
+		header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($path)) .' GMT');
+		header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
+		header('Etag: '. md5($path . $fmt));
+		readfile($path);
+	} else {
+		// video
+		// This might not work when X-Sendfile is disabled
+		header('Content-Type: video/'. $mime);
+		header('X-Sendfile: '. $path);
+	}
 	require('footer.php');
 ?>

--- a/foto.php
+++ b/foto.php
@@ -2,10 +2,12 @@
 	require('header.php');
 	require('media.php');
 
-	$path = $fotodir . $row['path'] . $row['name'];
+	$media = getUnit(UNIT_PHOTO);
+
+	$path = $fotodir . $media['path'] . $media['name'];
 
 	// send real filename instead of 'foto.php'
-	header('Content-disposition: inline; filename='. $row['name']);
+	header('Content-disposition: inline; filename='. $media['name']);
 	output($path);
 
 	require('footer.php');

--- a/header.php
+++ b/header.php
@@ -100,20 +100,20 @@
 	}
 
 	$videoExtensions = array(
-		'3gp'  => '3gp',
-		'3g2'  => '3g2',
-		'avi'  => 'avi',
-		'm4v'  => 'm4v',
-		'mkv'  => 'mkv',
-		'mpeg' => 'mp4', // these are all mp4, I think
-		'mpg'  => 'mp4',
-		'mpe'  => 'mp4',
+		'3gp'  => '3gpp',
+		'3g2'  => '3gpp2',
+		'avi'  => 'video/x-msvideo',
+		'm4v'  => 'x-m4v',
+		'mkv'  => 'x-matroska',
+		'mpeg' => 'mpeg',
+		'mpg'  => 'mpeg',
+		'mpe'  => 'mpeg',
 		'mp4'  => 'mp4',
-		'mov'  => 'mov',
+		'mov'  => 'quicktime',
 		'ogg'  => 'ogg',
 		'ogv'  => 'ogg',
 		'webm' => 'webm',
-		'wmv'  => 'wmv',
+		'wmv'  => 'x-ms-wmv',
 		// this should cover most (and should mostly be usable by ffmpeg)
 	);
 

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 	require('config.php');
 
 	/* Check the config */
-	if(!isset($fotodir, $cachedir, $domain, $absolute_url_path, $thumbs_per_row, $rows_of_thumbs, $imagick, $thumbnail_size, $foto_slider, $db_host, $db_user, $db_pass, $db_db, $log_queries)) {
+	if(!isset($fotodir, $cachedir, $domain, $absolute_url_path, $thumbs_per_row, $rows_of_thumbs, $foto_slider, $imagick, $thumbnail_size, $ffmpeg, $video_codecs, $video_resolutions, $db_host, $db_user, $db_pass, $db_db, $log_queries)) {
 		die("Missing settings");
 	}
 	if($log_queries)
@@ -86,6 +86,9 @@
 			template_assign('foto_slider_preload');
 			template_assign('foto_slider_timeout');
 		}
+
+		template_assign('video_codecs');
+		template_assign('video_resolutions');
 	}
 
 	/* Extensions */

--- a/header.php
+++ b/header.php
@@ -89,16 +89,33 @@
 	}
 
 	/* Extensions */
-	$extensions = array(
-		'gif' => 'gif', 
-		'jpg' => 'jpeg', 
-		'jpeg' => 'jpeg', 
-		'png' => 'png', 
-		'gif' => 'gif', 
+	$photoExtensions = array(
+		'gif'  => 'gif',
+		'jpg'  => 'jpeg',
+		'jpeg' => 'jpeg',
+		'png'  => 'png',
 	);
 	if($imagick) {
-		$extensions['bmp'] = 'bmp';
+		$photoExtensions['bmp'] = 'bmp';
 	}
+
+	$videoExtensions = array(
+		'3gp'  => '3gp',
+		'3g2'  => '3g2',
+		'avi'  => 'avi',
+		'm4v'  => 'm4v',
+		'mkv'  => 'mkv',
+		'mpeg' => 'mp4', // these are all mp4, I think
+		'mpg'  => 'mp4',
+		'mpe'  => 'mp4',
+		'mp4'  => 'mp4',
+		'mov'  => 'mov',
+		'ogg'  => 'ogg',
+		'ogv'  => 'ogg',
+		'webm' => 'webm',
+		'wmv'  => 'wmv',
+		// this should cover most (and should mostly be usable by ffmpeg)
+	);
 
 	/* Functions */
 	function show_template($tpl) {

--- a/header.php
+++ b/header.php
@@ -315,7 +315,7 @@
 		if($flags & UNIT_PHOTO) {
 			$res = sql_query("SELECT * FROM fa_photos WHERE path = %s AND name = %s", $path, $name);
 			if($photo = mysql_fetch_assoc($res)) {
-				$photo['type'] = 'photo';
+				// type already defined: 'photo' or 'video'
 				return $photo;
 			}
 		}

--- a/index.php
+++ b/index.php
@@ -111,6 +111,9 @@
 	$mode = 'index';
 	template_assign('mode');
 
+	$type = 'album';
+	template_assign('type');
+
 	template_assign('albums');
 	template_assign('photos');
 	if($album != '') {

--- a/large.php
+++ b/large.php
@@ -1,53 +1,23 @@
 <?php
-	// this file is almost the same as foto.php
 	require('header.php');
+	require('media.php');
 
 	if(!isset($_GET['foto'])) {
 		header('HTTP/1.1 400 Bad Request');
 		showTextAsImage("Missing parameter");
 	}
-	$row = getUnitByFullPath($_GET['foto'], UNIT_PHOTO);
-	if(!$row) {
-		header('HTTP/1.1 404 Not Found');
-		showTextAsImage('Photo not found');
-	}
 
-	if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
-		header('HTTP/1.1 403 Access denied');
-		showTextAsImage('Access denied');
-	}
-
-	if(!$mime = $photoExtensions[getext($row['name'])]) {
-		if(isset($videoExtensions[$_GET['codec']])) {
-			$mime = $_GET['codec'];
-		} else {
-			showTextAsImage("Unknown extension");
-		}
-	}
 
 	if ($row['type'] == 'photo') {
 		$path = $cachedir . $row['path'] . $row['name'] .'_large';
 	} else {
+		if(!$mime = $videoExtensions[$_GET['codec']]) {
+			header('HTTP/1.1 400 Bad Request');
+		}
 		$path = $cachedir . $row['path'] . $row['name'] .'_'. intval($_GET['res']) .'p.'. $mime;
 	}
 
-	if(!is_file($path)) {
-		header('HTTP/1.1 404 Not Found');
-		showTextAsImage("Image not cached", 600);
-	}
-	if ($row['type'] == 'photo') {
-		header('Content-type: image/'. $mime);
-		header('Pragma: public');
-		header('Cache-Control: public');
-		header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($path)) .' GMT');
-		header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
-		header('Etag: '. md5($path . $fmt));
-		readfile($path);
-	} else {
-		// video
-		// This might not work when X-Sendfile is disabled
-		header('Content-Type: video/'. $mime);
-		header('X-Sendfile: '. $path);
-	}
+	output($path);
+
 	require('footer.php');
 ?>

--- a/large.php
+++ b/large.php
@@ -2,19 +2,15 @@
 	require('header.php');
 	require('media.php');
 
-	if(!isset($_GET['foto'])) {
-		header('HTTP/1.1 400 Bad Request');
-		showTextAsImage("Missing parameter");
-	}
+	$media = getUnit(UNIT_PHOTO);
 
-
-	if ($row['type'] == 'photo') {
-		$path = $cachedir . $row['path'] . $row['name'] .'_large';
+	if ($media['type'] == 'photo') {
+		$path = $cachedir . $media['path'] . $media['name'] .'_large';
 	} else {
 		if(!$mime = $videoExtensions[$_GET['codec']]) {
 			header('HTTP/1.1 400 Bad Request');
 		}
-		$path = $cachedir . $row['path'] . $row['name'] .'_'. intval($_GET['res']) .'p.'. $mime;
+		$path = $cachedir . $media['path'] . $media['name'] .'_'. intval($_GET['res']) .'p.'. $mime;
 	}
 
 	output($path);

--- a/large.php
+++ b/large.php
@@ -16,7 +16,7 @@
 		showTextAsImage('Access denied');
 	}
 
-	if(!$mime = $extensions[getext($row['name'])]) {
+	if(!$mime = $photoExtensions[getext($row['name'])]) {
 		showTextAsImage("Unknown extension");
 	}
 

--- a/large.php
+++ b/large.php
@@ -13,7 +13,7 @@
 		$path = $cachedir . $media['path'] . $media['name'] .'_'. intval($_GET['res']) .'p.'. $mime;
 	}
 
-	output($path);
+	output($path, $media['name']);
 
 	require('footer.php');
 ?>

--- a/large.php
+++ b/large.php
@@ -1,4 +1,5 @@
 <?php
+	// this file is almost the same as foto.php
 	require('header.php');
 
 	if(!isset($_GET['foto'])) {
@@ -17,21 +18,36 @@
 	}
 
 	if(!$mime = $photoExtensions[getext($row['name'])]) {
-		showTextAsImage("Unknown extension");
+		if(isset($videoExtensions[$_GET['codec']])) {
+			$mime = $_GET['codec'];
+		} else {
+			showTextAsImage("Unknown extension");
+		}
 	}
 
-	$cachepath = $cachedir . $row['path'] . $row['name'] .'_large';
+	if ($row['type'] == 'photo') {
+		$path = $cachedir . $row['path'] . $row['name'] .'_large';
+	} else {
+		$path = $cachedir . $row['path'] . $row['name'] .'_'. intval($_GET['res']) .'p.'. $mime;
+	}
 
-	if(!is_file($cachepath)) {
+	if(!is_file($path)) {
 		header('HTTP/1.1 404 Not Found');
 		showTextAsImage("Image not cached", 600);
 	}
-	header('Content-type: image/'. $mime);
-	header('Pragma: public');
-	header('Cache-Control: public');
-	header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($cachepath)) .' GMT');
-	header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
-	header('Etag: '. md5($cachepath . $fmt));
-	readfile($cachepath);
+	if ($row['type'] == 'photo') {
+		header('Content-type: image/'. $mime);
+		header('Pragma: public');
+		header('Cache-Control: public');
+		header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($path)) .' GMT');
+		header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
+		header('Etag: '. md5($path . $fmt));
+		readfile($path);
+	} else {
+		// video
+		// This might not work when X-Sendfile is disabled
+		header('Content-Type: video/'. $mime);
+		header('X-Sendfile: '. $path);
+	}
 	require('footer.php');
 ?>

--- a/media.php
+++ b/media.php
@@ -38,7 +38,7 @@
 
 		if ($name)
 			// send real filename instead of php file name
-			header('Content-disposition: inline; filename='. $media['name']);
+			header('Content-disposition: inline; filename='. $name);
 		header('Content-type: '. $mime);
 		header('X-Sendfile: '. $path);
 	}

--- a/media.php
+++ b/media.php
@@ -1,18 +1,21 @@
 <?php
 
-	if(!isset($_GET['foto'])) {
-		header('HTTP/1.1 400 Bad Request');
-		showTextAsImage("Missing parameter");
-	}
-	$row = getUnitByFullPath($_GET['foto'], UNIT_PHOTO);
-	if(!$row) {
-		header('HTTP/1.1 404 Not Found');
-		showTextAsImage('Photo not found');
-	}
+	function getUnit ($flags) {
+		if(!isset($_GET['foto'])) {
+			header('HTTP/1.1 400 Bad Request');
+			showTextAsImage("Missing parameter");
+		}
+		$row = getUnitByFullPath($_GET['foto'], $flags);
+		if(!$row) {
+			header('HTTP/1.1 404 Not Found');
+			showTextAsImage('Photo not found');
+		}
 
-	if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
-		header('HTTP/1.1 403 Access denied');
-		showTextAsImage('Access denied');
+		if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
+			header('HTTP/1.1 403 Access denied');
+			showTextAsImage('Access denied');
+		}
+		return $row;
 	}
 
 	function output ($path) {

--- a/media.php
+++ b/media.php
@@ -1,0 +1,25 @@
+<?php
+
+	if(!isset($_GET['foto'])) {
+		header('HTTP/1.1 400 Bad Request');
+		showTextAsImage("Missing parameter");
+	}
+	$row = getUnitByFullPath($_GET['foto'], UNIT_PHOTO);
+	if(!$row) {
+		header('HTTP/1.1 404 Not Found');
+		showTextAsImage('Photo not found');
+	}
+
+	if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
+		header('HTTP/1.1 403 Access denied');
+		showTextAsImage('Access denied');
+	}
+
+	function output ($path) {
+		if(!is_file($path)) {
+			header('HTTP/1.1 404 Not Found');
+			showTextAsImage("Image not cached", 600);
+		}
+		header('Content-type: '. finfo_file(finfo_open($path), FILEINFO_MIME));
+		header('X-Sendfile: '. $path);
+	}

--- a/media.php
+++ b/media.php
@@ -1,5 +1,8 @@
 <?php
 
+	/* Get current unit (album/photo/video),
+	   wrapper for getUnitByFullPath().
+	 */
 	function getUnit ($flags) {
 		if(!isset($_GET['foto'])) {
 			header('HTTP/1.1 400 Bad Request');
@@ -18,11 +21,24 @@
 		return $row;
 	}
 
-	function output ($path) {
+	/* Send a file to client.
+	   $path is the path of the file, $name is the original name of the file.
+	 */
+	function output ($path, $name=NULL) {
 		if(!is_file($path)) {
 			header('HTTP/1.1 404 Not Found');
 			showTextAsImage("Image not cached", 600);
 		}
-		header('Content-type: '. finfo_file(finfo_open($path), FILEINFO_MIME));
+
+		$mime = finfo_file(finfo_open(), $path, FILEINFO_MIME_TYPE);
+		// hack, as long as webm isn't supported by the magic database, this is needed
+		if (isset($_GET['codec']) && $_GET['codec'] == 'webm') {
+			$mime = 'video/webm';
+		}
+
+		if ($name)
+			// send real filename instead of php file name
+			header('Content-disposition: inline; filename='. $media['name']);
+		header('Content-type: '. $mime);
 		header('X-Sendfile: '. $path);
 	}

--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ if (type == 'photo') {
 	if (sliding) {
 		setTimeout('slider_next()', slider_timeout*1000);
 	}
-} else {
+} else if (type == 'video') {
 	window.addEventListener('DOMContentLoaded', function () {
 		var video = document.getElementById('video');
 		if (document.getElementById('resolution').value != localStorage.videoResolution) {

--- a/script.js
+++ b/script.js
@@ -11,18 +11,27 @@ function slider_preload() {
 	document.body.appendChild(el);
 }
 
-// toggle between 360p and 720p videos
+// apply change in resolution to <video>
 function updateResolution () {
 	var resolution = document.getElementById('resolution').value;
 	localStorage.videoResolution = resolution;
 	var video      = document.getElementById('video');
-	var format     = video.canPlayType('video/mp4') ? 'mp4' : 'webm';
+	var codec = null;
+	for (var i=0; i<codecs.length; i++) {
+		if (video.canPlayType('video/'+codecs[i])) {
+			codec = codecs[i];
+		}
+	}
+	if (!codec) {
+		// problem! Just choose the first. It probably won't play anyway.
+		codec = codecs[0];
+	}
 	// workaround for bug in Chrome on Linux (mp4 doesn't play but is still advertized to play)
-	if (video.canPlayType('video/webm') && navigator.userAgent.indexOf('Linux') && navigator.userAgent.indexOf('Chrome')) {
-		format = 'webm';
+	if (video.canPlayType('video/webm') && navigator.userAgent.indexOf('Linux') && navigator.userAgent.indexOf('Chrome') && codecs.indexOf('webm') != -1) {
+		codec = 'webm';
 	}
 	// all browsers supporting <video> support querySelector
-	var src = document.querySelector('source[type="video/'+format+'"][data-resolution="'+resolution+'"]').src;
+	var src = document.querySelector('source[type="video/'+codec+'"][data-resolution="'+resolution+'"]').src;
 	var position = video.currentTime;
 	var playing  = !video.paused;
 	video.src = src;

--- a/script.js
+++ b/script.js
@@ -1,0 +1,58 @@
+'use strict';
+function slider_next() {
+	location.href = next;
+}
+
+function slider_preload() {
+	var el=document.createElement('img');
+	el.src= preload;
+	el.style.display = 'none';
+	el.alt = 'Fotoslider Preloader';
+	document.body.appendChild(el);
+}
+
+// toggle between 360p and 720p videos
+function updateResolution () {
+	var resolution = document.getElementById('resolution').value;
+	localStorage.videoResolution = resolution;
+	var video      = document.getElementById('video');
+	var format     = video.canPlayType('video/mp4') ? 'mp4' : 'webm';
+	// workaround for bug in Chrome on Linux (mp4 doesn't play but is still advertized to play)
+	if (video.canPlayType('video/webm') && navigator.userAgent.indexOf('Linux') && navigator.userAgent.indexOf('Chrome')) {
+		format = 'webm';
+	}
+	// all browsers supporting <video> support querySelector
+	var src = document.querySelector('source[type="video/'+format+'"][data-resolution="'+resolution+'"]').src;
+	var position = video.currentTime;
+	var playing  = !video.paused;
+	video.src = src;
+	video.addEventListener('loadedmetadata', function () {
+		video.currentTime = position;
+		if (playing)
+			video.play();
+	}, false);
+}
+
+if (type == 'photo') {
+	if (sliding) {
+		setTimeout('slider_next()', slider_timeout*1000);
+	}
+} else {
+	window.addEventListener('DOMContentLoaded', function () {
+		var video = document.getElementById('video');
+		if (document.getElementById('resolution').value != localStorage.videoResolution) {
+			if (localStorage.videoResolution)
+				document.getElementById('resolution').value  = localStorage.videoResolution;
+			updateResolution();
+		}
+		if (sliding) {
+			video.addEventListener('ended', function () {
+				// don't jump to the next immediately
+				setTimeout(function () {
+					if (!video.paused) return;
+					slider_next();
+				}, 1000);
+			}, false);
+		}
+	}, false);
+}

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -15,7 +15,8 @@
 			var preload = 'foto.php?foto=<?= urlencode($next) ?>';
 			var sliding = <?= $sliding ? 'true' : 'false' ?>;
 			var slider_timeout = <?= $foto_slider_timeout ?>;
-			var type    = <?= "'". $type ."'" ?>
+			var type    = '<?= $type ?>';
+			var codecs  = <?= json_encode($video_codecs) ?>;
 		</script>
 		<script type="text/javascript" src="script.js"></script>
 <?PHP if($sliding) { ?>

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -11,10 +11,14 @@
 		<link href="http://www.karpenoktem.nl/base/styles/common/" rel="stylesheet" type="text/css" />
 		<link type="text/css" rel="stylesheet" href="style.css" />
 		<script type="text/javascript">
-			var next    = "view.php?slide&foto=<?= urlencode($next) ?>";
-			var preload = 'foto.php?foto=<?= urlencode($next) ?>';
 			var sliding = <?= $sliding ? 'true' : 'false' ?>;
+<?php if ($sliding) { ?>
+			var next    = "view.php?slide&foto=<?= urlencode($next) ?>";
+<?php   if ($foto_slider_preload) { ?>
+			var preload = 'foto.php?foto=<?= urlencode($next) ?>';
+<?php   } ?>
 			var slider_timeout = <?= $foto_slider_timeout ?>;
+<?php } ?>
 			var type    = '<?= $type ?>';
 			var codecs  = <?= json_encode($video_codecs) ?>;
 		</script>

--- a/templates/header.tpl
+++ b/templates/header.tpl
@@ -10,22 +10,15 @@
 		<![endif]-->
 		<link href="http://www.karpenoktem.nl/base/styles/common/" rel="stylesheet" type="text/css" />
 		<link type="text/css" rel="stylesheet" href="style.css" />
-<?PHP if($sliding) { ?>
 		<script type="text/javascript">
-			function slider_next() {
-				location.href="view.php?slide&foto=<?= urlencode($next) ?>";
-			}
-<?PHP if($foto_slider_preload) { ?>
-			function slider_preload() {
-				var el=document.createElement('img');
-				el.src='foto.php?foto=<?= urlencode($next) ?>';
-				el.style.display='none';
-				el.alt='Fotoslider Preloader';
-				document.body.appendChild(el);
-			}
-<?PHP } ?>
-			setTimeout('slider_next()', <?= $foto_slider_timeout*1000 ?>);
+			var next    = "view.php?slide&foto=<?= urlencode($next) ?>";
+			var preload = 'foto.php?foto=<?= urlencode($next) ?>';
+			var sliding = <?= $sliding ? 'true' : 'false' ?>;
+			var slider_timeout = <?= $foto_slider_timeout ?>;
+			var type    = <?= "'". $type ."'" ?>
 		</script>
+		<script type="text/javascript" src="script.js"></script>
+<?PHP if($sliding) { ?>
 		<noscript>
 			<meta http-equiv="refresh" content="<?= $foto_slider_timeout ?>; url=view.php?slide&foto=<?= urlencode($next) ?>">
 		</noscript>

--- a/templates/view.tpl
+++ b/templates/view.tpl
@@ -42,7 +42,7 @@
 				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=<?= $codec ?>&res=<?= $res ?>"  type="video/<?= $codec ?>"  data-resolution="<?= $res ?>"/>
 <?PHP     } ?>
 <?PHP   } ?>
-				<p>Je browser ondersteund geen html5 video (gebruik <a href="http://windows.microsoft.com/nl-NL/internet-explorer/downloads/ie-9/worldwide-languages">IE9</a>+ of een recente versie van <a href="http://www.mozilla.org/nl/firefox/new/">Firefox</a>, <a href="https://www.google.com/intl/nl/chrome/browser/">Chrome</a>, <a href="http://www.apple.com/safari/">Safari</a> of <a href="http://www.opera.com/">Opera</a>). Toch willen we je niet in de steek laten en proberen we hieronder de video af te spelen.</p>
+				<p>Je browser ondersteunt geen html5 video (gebruik <a href="http://windows.microsoft.com/nl-NL/internet-explorer/downloads/ie-9/worldwide-languages">IE9</a>+ of een recente versie van <a href="http://www.mozilla.org/nl/firefox/new/">Firefox</a>, <a href="https://www.google.com/intl/nl/chrome/browser/">Chrome</a>, <a href="http://www.apple.com/safari/">Safari</a> of <a href="http://www.opera.com/">Opera</a>). Toch willen we je niet in de steek laten en proberen we hieronder de video af te spelen.</p>
 <?PHP   if (count($video_resolutions) == 2 && in_array('mp4', $video_codecs)) { ?>
 				<p>Download video in <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{0} ?>">lage resolutie (<?= $video_resolutions{0} ?>, sneller)</a> of <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{1} ?>">hoge resolutie (<?= $video_resolutions{1} ?>, groter/beter)</a>.</p>
 <?PHP   } else { ?>

--- a/templates/view.tpl
+++ b/templates/view.tpl
@@ -18,30 +18,48 @@
 					</td>
 				</tr>
 			</table>
-<?PHP if($sliding) { ?>
-<?PHP if($foto_slider_preload) { ?>
+<?PHP if($type == 'photo') { ?>
+<?PHP   if($sliding) { ?>
+<?PHP     if($foto_slider_preload) { ?>
 			<img class="large" src="large.php?foto=<?= urlencode($foto) ?>" onLoad="slider_preload();" onError="slider_next();">
 			<noscript>
 				<img src="large.php?foto=<?= urlencode($next) ?>" style="display: none;" alt="Fotoslider Preloader">
 			</noscript>
-<?PHP } else { ?>
+<?PHP     } else { ?>
 			<img class="large" src="large.php?foto=<?= urlencode($foto) ?>" onError="slider_next();">
-<?PHP } ?>
-<?PHP } else { ?>
+<?PHP     } ?>
+<?PHP   } else { ?>
 			<img class="large" src="large.php?foto=<?= urlencode($foto) ?>">
+<?PHP   } ?>
+<?PHP } else { ?>
+<?PHP   if($sliding) { ?>
+			<video id="video" controls="" autoplay="" onError="slider_next();">
+<?PHP   } else { ?>
+			<video id="video" controls="" autoplay="">
+<?PHP   } ?>
+				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=360p"  type="video/mp4"  data-resolution="360p"/>
+				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=720p"  type="video/mp4"  data-resolution="720p"/>
+				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=webm&res=360p" type="video/webm" data-resolution="360p"/>
+				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=webm&res=720p" type="video/webm" data-resolution="720p"/>
+				Download video in <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=360p">lage resolutie (360p, sneller)</a> of <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=720p">hoge resolutie (720p, groter/beter)</a>.
+			</video><br/>
+			<select id="resolution" onchange="updateResolution()" title="Video resolutie">
+					<option selected="">360p</option>
+					<option>720p</option>
+			</select>
 <?PHP } ?>
 			<div class="nav">
 				<a href="foto.php?foto=<?= urlencode($foto) ?>">Direct link</a>
 <?PHP if($foto_slider) { ?>
-<?PHP if($sliding) { ?>
+<?PHP   if($sliding) { ?>
 				- <a href="view.php?foto=<?= urlencode($foto) ?>">Stop slideshow</a>
-<?PHP } else { ?>
-<?PHP if($next) { ?>
+<?PHP   } else { ?>
+<?PHP     if($next) { ?>
 				- <a href="view.php?slide&foto=<?= urlencode($foto) ?>">Start slideshow</a>
-<?PHP } else if ($prev) { ?>
+<?PHP     } else if ($prev) { ?>
 				- <a href="view.php?slide&foto=<?= urlencode($first) ?>">Start slideshow</a>
-<?PHP } ?>
-<?PHP } ?>
+<?PHP     } ?>
+<?PHP   } ?>
 <?PHP } ?>
 			</div>
 <?PHP show_template('footer.tpl'); ?>

--- a/templates/view.tpl
+++ b/templates/view.tpl
@@ -42,7 +42,7 @@
 				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=<?= $codec ?>&res=<?= $res ?>"  type="video/<?= $codec ?>"  data-resolution="<?= $res ?>"/>
 <?PHP     } ?>
 <?PHP   } ?>
-				<p>Je browser ondersteund geen html5 video (gebruik <a href="http://windows.microsoft.com/nl-NL/internet-explorer/downloads/ie-9/worldwide-languages">IE9</a>+ of een recente versie van <a href="http://www.mozilla.org/nl/firefox/new/">Firefox</a>, <a href="https://www.google.com/intl/nl/chrome/browser/">Chrome</a>, <a href="http://www.apple.com/safari/">Safari</a> of <a href="http://www.opera.com/">Opera</a>).</p>
+				<p>Je browser ondersteund geen html5 video (gebruik <a href="http://windows.microsoft.com/nl-NL/internet-explorer/downloads/ie-9/worldwide-languages">IE9</a>+ of een recente versie van <a href="http://www.mozilla.org/nl/firefox/new/">Firefox</a>, <a href="https://www.google.com/intl/nl/chrome/browser/">Chrome</a>, <a href="http://www.apple.com/safari/">Safari</a> of <a href="http://www.opera.com/">Opera</a>). Toch willen we je niet in de steek laten en proberen we hieronder de video af te spelen.</p>
 <?PHP   if (count($video_resolutions) == 2 && in_array('mp4', $video_codecs)) { ?>
 				<p>Download video in <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{0} ?>">lage resolutie (<?= $video_resolutions{0} ?>, sneller)</a> of <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{1} ?>">hoge resolutie (<?= $video_resolutions{1} ?>, groter/beter)</a>.</p>
 <?PHP   } else { ?>
@@ -53,6 +53,7 @@
 <?PHP     } ?>
 				</ul>
 <?PHP   } ?>
+				<object data="large.php?foto=<?= urlencode($foto) ?>&codec=<?= in_array('mp4', $video_codecs) ? 'mp4' : $video_codecs{0} ?>&res=<?= $video_resolutions{0} ?>" type="video/<?= in_array('mp4', $video_codecs) ? 'mp4' : $video_codecs{0} ?>" width="<?= $video_resolutions{0}*16/9 ?>" height="<?= $video_resolutions{0}+20 ?>">Helaas, video afspelen is niet gelukt.</object>
 			</video><br/>
 			<select id="resolution" onchange="updateResolution()" title="Video resolutie">
 <?PHP   foreach ($video_resolutions as $res) { ?>

--- a/templates/view.tpl
+++ b/templates/view.tpl
@@ -37,15 +37,31 @@
 <?PHP   } else { ?>
 			<video id="video" controls="" autoplay="">
 <?PHP   } ?>
-				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=360p"  type="video/mp4"  data-resolution="360p"/>
-				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=720p"  type="video/mp4"  data-resolution="720p"/>
-				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=webm&res=360p" type="video/webm" data-resolution="360p"/>
-				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=webm&res=720p" type="video/webm" data-resolution="720p"/>
-				Download video in <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=360p">lage resolutie (360p, sneller)</a> of <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=720p">hoge resolutie (720p, groter/beter)</a>.
+<?PHP   foreach ($video_codecs as $codec) { ?>
+<?PHP     foreach ($video_resolutions as $res) { ?>
+				<source src="large.php?foto=<?= urlencode($foto) ?>&codec=<?= $codec ?>&res=<?= $res ?>"  type="video/<?= $codec ?>"  data-resolution="<?= $res ?>"/>
+<?PHP     } ?>
+<?PHP   } ?>
+				<p>Je browser ondersteund geen html5 video (gebruik <a href="http://windows.microsoft.com/nl-NL/internet-explorer/downloads/ie-9/worldwide-languages">IE9</a>+ of een recente versie van <a href="http://www.mozilla.org/nl/firefox/new/">Firefox</a>, <a href="https://www.google.com/intl/nl/chrome/browser/">Chrome</a>, <a href="http://www.apple.com/safari/">Safari</a> of <a href="http://www.opera.com/">Opera</a>).</p>
+<?PHP   if (count($video_resolutions) == 2 && in_array('mp4', $video_codecs)) { ?>
+				<p>Download video in <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{0} ?>">lage resolutie (<?= $video_resolutions{0} ?>, sneller)</a> of <a href="large.php?foto=<?= urlencode($foto) ?>&codec=mp4&res=<?= $video_resolutions{1} ?>">hoge resolutie (<?= $video_resolutions{1} ?>, groter/beter)</a>.</p>
+<?PHP   } else { ?>
+				<p>Video beschikbaar in de volgende resoluties (kleiner is sneller te downloaden):</p>
+				<ul>
+<?PHP     foreach ($video_resolutions as $res) { ?>
+					<li><a href="large.php?foto=<?= urlencode($foto) ?>&codec=<?= $video_codecs{0} ?>&res=<?= $res ?>"><?= $res ?></a></li>
+<?PHP     } ?>
+				</ul>
+<?PHP   } ?>
 			</video><br/>
 			<select id="resolution" onchange="updateResolution()" title="Video resolutie">
-					<option selected="">360p</option>
-					<option>720p</option>
+<?PHP   foreach ($video_resolutions as $res) { ?>
+<?PHP     if ($res == $video_resolutions{0}) { ?>
+					<option selected=""><?= $res ?></option>
+<?PHP     } else { ?>
+					<option><?= $res ?></option>
+<?PHP     } ?>
+<?PHP   } ?>
 			</select>
 <?PHP } ?>
 			<div class="nav">

--- a/thumbnail.php
+++ b/thumbnail.php
@@ -30,7 +30,7 @@
 		}
 	}
 
-	if(!$mime = $extensions[getext($row['name'])]) {
+	if(!$mime = $photoExtensions[getext($row['name'])]) {
 		showTextAsImage("Unknown extension");
 	}
 

--- a/thumbnail.php
+++ b/thumbnail.php
@@ -1,57 +1,33 @@
 <?php
 	require('header.php');
-	# showTextAsImage('temporary disabled for performance');
+	require('media.php');
 
-	if(!isset($_GET['foto'])) {
-		header('HTTP/1.1 400 Bad Request');
-		showTextAsImage("Missing parameter");
-	}
-	$row = getUnitByFullPath($_GET['foto'], UNIT_BOTH);
-	if(!$row) {
-		header('HTTP/1.1 404 Not Found');
-		showTextAsImage('Photo/album not found');
-	}
+	// $photo may be an album
+	$photo = getUnit(UNIT_BOTH);
 
-	if(!in_array($row['visibility'], getVisibleVisibilities()) || !isPathVisible($row['path'])) {
-		header('HTTP/1.1 403 Access denied');
-		showTextAsImage('Access denied');
+	// if the thumbnail ($photo) turns out to be an album, get a random image from the albums
+	if($photo['type'] == 'album') {
+		$photo = getPhotoFromAlbum($photo);
 	}
+	// now $photo is really a photo
 
-	if($row['type'] == 'album') {
-		$res = sql_query("SELECT path, name FROM fa_albums WHERE path LIKE %s AND visibility IN (%S)", $row['path'] . $row['name'] .'/%', getVisibleVisibilities());
-		$subalbums = array($row['path'] . $row['name'] .'/');
-		while($album = mysql_fetch_assoc($res)) {
-			$subalbums[] = $album['path'] . $album['name'] .'/';
+	$path = $cachedir . $photo['path'] . $photo['name'] .'_thumb';
+
+	output($path);
+
+	require('footer.php');
+
+	function getPhotoFromAlbum ($album) {
+		$res = sql_query("SELECT path, name FROM fa_albums WHERE path LIKE %s AND visibility IN (%S)", $album['path'] . $album['name'] .'/%', getVisibleVisibilities());
+		$subalbums = array($album['path'] . $album['name'] .'/');
+		while($subalbum = mysql_fetch_assoc($res)) {
+			$subalbums[] = $subalbum['path'] . $subalbum['name'] .'/';
 		}
 		$res = sql_query("SELECT * FROM fa_photos WHERE path IN(%S) AND FIND_IN_SET('thumb', cached) AND visibility IN (%S) ORDER BY RAND() LIMIT 1", $subalbums, getVisibleVisibilities());
-		if(!$row = mysql_fetch_assoc($res)) { 
+		if(!$photo= mysql_fetch_assoc($res)) { 
 			header('HTTP/1.1 404 Not Found');
 			showTextAsImage('No photo with thumbnail found for album');
 		}
+		return $photo;
 	}
-
-	if(isset($photoExtensions[getext($row['name'])])) {
-		$mime = $photoExtensions[getext($row['name'])];
-	} else {
-		if(isset($videoExtensions[getext($row['name'])])) {
-			$mime = 'jpeg';
-		} else {
-			showTextAsImage("Unknown extension");
-		}
-	}
-
-	$cachepath = $cachedir . $row['path'] . $row['name'] .'_thumb';
-
-	if(!is_file($cachepath)) {
-		header('HTTP/1.1 404 Not Found');
-		showTextAsImage("No thumbnail");
-	}
-	header('Content-type: image/'. $mime);
-	header('Pragma: public');
-	header('Cache-Control: public');
-	header('Last-Modified: '. gmdate('D, d M Y H:i:s', $fmt = filemtime($cachepath)) .' GMT');
-	header('Expires: '. gmdate('D, d M Y H:i:s', time()+60*60).' GMT');
-	header('Etag: '. md5($cachepath . $fmt));
-	readfile($cachepath);
-	require('footer.php');
 ?>

--- a/thumbnail.php
+++ b/thumbnail.php
@@ -30,8 +30,14 @@
 		}
 	}
 
-	if(!$mime = $photoExtensions[getext($row['name'])]) {
-		showTextAsImage("Unknown extension");
+	if(isset($photoExtensions[getext($row['name'])])) {
+		$mime = $photoExtensions[getext($row['name'])];
+	} else {
+		if(isset($videoExtensions[getext($row['name'])])) {
+			$mime = 'jpeg';
+		} else {
+			showTextAsImage("Unknown extension");
+		}
 	}
 
 	$cachepath = $cachedir . $row['path'] . $row['name'] .'_thumb';

--- a/updatecache.php
+++ b/updatecache.php
@@ -11,7 +11,6 @@
 	$lock = lock_db();
 
 	/* First, cache all photos (they're probably far quicker) */
-	echo "Caching photos...\n";
 
 	$res = sql_query("SELECT * FROM fa_photos WHERE type='photo' AND ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('large', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
 	while($row = mysql_fetch_assoc($res)) {
@@ -55,7 +54,6 @@
 	}
 
 	/* After that, transcode videos (potentially takes a looong time) */
-	echo "\nCaching/transcoding videos...\n";
 
 	$resolution_constraints_sql = '';
 	foreach ($video_resolutions as $res) {

--- a/updatecache.php
+++ b/updatecache.php
@@ -4,7 +4,9 @@
 
 
 	/* First, cache all photos (they're probably far quicker) */
-	$res = sql_query("SELECT * FROM fa_photos WHERE ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('large', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
+	echo "Caching photos...\n";
+
+	$res = sql_query("SELECT * FROM fa_photos WHERE type='photo' AND ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('large', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
 	while($row = mysql_fetch_assoc($res)) {
 		echo '==> '. $row['path'] . $row['name'] ."\n";
 		if(!is_dir($cachedir . $row['path'])) {
@@ -46,8 +48,9 @@
 	}
 
 	/* After that, transcode videos (potentially takes a looong time) */
-	require('footer.php');
-	$res = sql_query("SELECT * FROM fa_videos WHERE ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('360p', cached) OR NOT FIND_IN_SET('720p', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
+	echo "Caching/transcoding videos...\n";
+
+	$res = sql_query("SELECT * FROM fa_photos WHERE type='video' AND ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('360p', cached) OR NOT FIND_IN_SET('720p', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
 	$ffmpeg_thumbnail_size = substr($thumbnail_size, 0, 1) == 'x' ? '-1:'.substr($thumbnail_size, 1) : substr($thumbnail_size, 0, -1).':-1';
 	while ($row = mysql_fetch_assoc($res)) {
 		echo '==> '. $row['path'] . $row['name'] ."\n";
@@ -95,10 +98,12 @@
 		}
 
 		echo "===> Updating";
-		sql_query("UPDATE fa_videos SET cached=%s WHERE id=%i",
+		sql_query("UPDATE fa_photos SET cached=%s WHERE id=%i",
 				implode(',', $cached), $row['id']);
 		echo "\n";
 	}
+
+	require('footer.php');
 
 	// transcode one video with ffmpeg
 	function transcode($input, $output, $bitrate, $size) {

--- a/updatecache.php
+++ b/updatecache.php
@@ -115,7 +115,7 @@
 	function transcode($input, $output, $bitrate, $size) {
 		global $ffmpeg;
 		// FUTURE TODO: remove '-strict experimental' (this is not needed in at least ffmpeg 1.1)
-		$command = $ffmpeg .' -i '. escapeshellarg($input) .' -strict experimental -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
+		$command = $ffmpeg .' -i '. escapeshellarg($input) .' -strict experimental -ab 128k -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
 		passthru($command, $ret);
 		if($ret != 0) {
 			echo "ERROR while transcoding via $command\n";

--- a/updatecache.php
+++ b/updatecache.php
@@ -3,6 +3,7 @@
 	require('header.php');
 	require('dbutils.php');
 
+	// warning: when not run from the CLI, the lock may remain in case of errors.
 	$lock = lock_db();
 
 	/* First, cache all photos (they're probably far quicker) */

--- a/updatecache.php
+++ b/updatecache.php
@@ -2,6 +2,8 @@
 	$cli_mode = true;
 	require('header.php');
 
+
+	/* First, cache all photos (they're probably far quicker) */
 	$res = sql_query("SELECT * FROM fa_photos WHERE ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('large', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
 	while($row = mysql_fetch_assoc($res)) {
 		echo '==> '. $row['path'] . $row['name'] ."\n";
@@ -12,6 +14,8 @@
 		if(in_array('invalidated', $cached)) {
 			$cached = array();
 		}
+
+		// create thumbnail if necessary
 		if(!in_array('thumb', $cached)) {
 			echo "===> Thumbnail\n";
 			passthru('convert -resize '. $thumbnail_size .' -rotate '. intval($row['rotation']) .' '. escapeshellarg($fotodir . $row['path'] . $row['name']) .' '. escapeshellarg($cachedir . $row['path'] . $row['name'] .'_thumb'), $ret);
@@ -22,6 +26,8 @@
 			}
 			$cached[] = 'thumb';
 		}
+
+		// create larger photo if necessary
 		if(!in_array('large', $cached)) {
 			echo "===> Large\n";
 			passthru('convert -resize '. $large_size .' -rotate '. intval($row['rotation']) .' '. escapeshellarg($fotodir . $row['path'] . $row['name']) .' '. escapeshellarg($cachedir . $row['path'] . $row['name'] .'_large'), $ret);
@@ -32,10 +38,76 @@
 			}
 			$cached[] = 'large';
 		}
+
 		echo "===> Updating";
 		sql_query("UPDATE fa_photos SET cached=%s WHERE id=%i",
 				implode(',', $cached), $row['id']);
 		echo "\n";
 	}
+
+	/* After that, transcode videos (potentially takes a looong time) */
 	require('footer.php');
+	$res = sql_query("SELECT * FROM fa_videos WHERE ((NOT FIND_IN_SET('thumb', cached) OR NOT FIND_IN_SET('360p', cached) OR NOT FIND_IN_SET('720p', cached)) OR FIND_IN_SET('invalidated', cached)) AND visibility IN('hidden', 'leden', 'world') ORDER BY FIND_IN_SET('invalidated', cached), RAND()");
+	$ffmpeg_thumbnail_size = substr($thumbnail_size, 0, 1) == 'x' ? '-1:'.substr($thumbnail_size, 1) : substr($thumbnail_size, 0, -1).':-1';
+	while ($row = mysql_fetch_assoc($res)) {
+		echo '==> '. $row['path'] . $row['name'] ."\n";
+		if(!is_dir($cachedir . $row['path'])) {
+			mkdir($cachedir . $row['path'], 0755, true);
+		}
+		$cached = explode(',', $row['cached']);
+		if(in_array('invalidated', $cached)) {
+			$cached = array();
+		}
+
+		// extract poster frame from video and resize
+		if(!in_array('thumb', $cached)) {
+			echo "===> Thumbnail\n";
+			$command = 'ffmpeg -loglevel warning -i ' . escapeshellarg($fotodir . $row['path'] . $row['name']) . ' -ss 00:00:00.50 -vf "scale=' . $ffmpeg_thumbnail_size . '" -vcodec mjpeg -vframes 1 -f image2 ' . escapeshellarg($cachedir . $row['path'] . $row['name'] .'_thumb');
+			passthru($command, $ret);
+			if($ret != 0) {
+				echo "ERROR while creating thumbnail via $command\n";
+				var_dump($row);
+				exit;
+			}
+			$cached[] = 'thumb';
+		}
+
+		// transcode 360p version if necessary
+		if (!in_array('360p', $cached)) {
+			echo "===> 360p\n";
+			foreach (array('mp4', 'webm') as $format) {
+				transcode(escapeshellarg($fotodir . $row['path'] . $row['name']),
+						escapeshellarg($cachedir . $row['path'] . $row['name'] .'_360p.'. $format),
+						'500k', '360');
+			}
+			$cached[] = '360p';
+		}
+
+		// transcode 720p version if necessary
+		if (!in_array('720p', $cached)) {
+			echo "===> 720p\n";
+			foreach (array('mp4', 'webm') as $format) {
+				transcode(escapeshellarg($fotodir . $row['path'] . $row['name']),
+						escapeshellarg($cachedir . $row['path'] . $row['name'] .'_720p.'. $format),
+						'2500k', '720');
+			}
+			$cached[] = '720p';
+		}
+
+		echo "===> Updating";
+		sql_query("UPDATE fa_videos SET cached=%s WHERE id=%i",
+				implode(',', $cached), $row['id']);
+		echo "\n";
+	}
+
+	// transcode one video with ffmpeg
+	function transcode($input, $output, $bitrate, $size) {
+		$command = 'ffmpeg -loglevel warning -i '. $input .' -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. $output;
+		passthru($command, $ret);
+		if($ret != 0) {
+			echo "ERROR while transcoding via $command\n";
+			var_dump($row);
+			exit;
+		}
+	}
 ?>

--- a/updatecache.php
+++ b/updatecache.php
@@ -1,7 +1,9 @@
 <?php
 	$cli_mode = true;
 	require('header.php');
+	require('dbutils.php');
 
+	$lock = lock_db();
 
 	/* First, cache all photos (they're probably far quicker) */
 	echo "Caching photos...\n";
@@ -97,6 +99,9 @@
 				implode(',', $cached), $row['id']);
 		echo "\n";
 	}
+
+	// not really needed when run from the command line
+	unlock_db($lock);
 
 	require('footer.php');
 

--- a/updatecache.php
+++ b/updatecache.php
@@ -116,11 +116,10 @@
 	// transcode one video with ffmpeg
 	function transcode($input, $output, $bitrate, $size) {
 		global $ffmpeg;
-		$command = $ffmpeg .' -i '. escapeshellarg($input) .' -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
+		$command = $ffmpeg .' -i '. escapeshellarg($input) .' -strict experimental -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
 		passthru($command, $ret);
 		if($ret != 0) {
 			echo "ERROR while transcoding via $command\n";
-			var_dump($row);
 			exit;
 		}
 	}

--- a/updatecache.php
+++ b/updatecache.php
@@ -116,6 +116,7 @@
 	// transcode one video with ffmpeg
 	function transcode($input, $output, $bitrate, $size) {
 		global $ffmpeg;
+		// FUTURE TODO: remove '-strict experimental' (this is not needed in at least ffmpeg 1.1)
 		$command = $ffmpeg .' -i '. escapeshellarg($input) .' -strict experimental -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
 		passthru($command, $ret);
 		if($ret != 0) {

--- a/updatecache.php
+++ b/updatecache.php
@@ -79,8 +79,8 @@
 		if (!in_array('360p', $cached)) {
 			echo "===> 360p\n";
 			foreach (array('mp4', 'webm') as $format) {
-				transcode(escapeshellarg($fotodir . $row['path'] . $row['name']),
-						escapeshellarg($cachedir . $row['path'] . $row['name'] .'_360p.'. $format),
+				transcode($fotodir . $row['path'] . $row['name'],
+						$cachedir . $row['path'] . $row['name'] .'_360p.'. $format,
 						'500k', '360');
 			}
 			$cached[] = '360p';
@@ -90,8 +90,8 @@
 		if (!in_array('720p', $cached)) {
 			echo "===> 720p\n";
 			foreach (array('mp4', 'webm') as $format) {
-				transcode(escapeshellarg($fotodir . $row['path'] . $row['name']),
-						escapeshellarg($cachedir . $row['path'] . $row['name'] .'_720p.'. $format),
+				transcode($fotodir . $row['path'] . $row['name'],
+						$cachedir . $row['path'] . $row['name'] .'_720p.'. $format,
 						'2500k', '720');
 			}
 			$cached[] = '720p';
@@ -107,7 +107,7 @@
 
 	// transcode one video with ffmpeg
 	function transcode($input, $output, $bitrate, $size) {
-		$command = 'ffmpeg -loglevel warning -i '. $input .' -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. $output;
+		$command = 'ffmpeg -loglevel warning -i '. escapeshellarg($input) .' -b:v '. $bitrate .' -vf "scale=-1:'. $size .'" -y '. escapeshellarg($output);
 		passthru($command, $ret);
 		if($ret != 0) {
 			echo "ERROR while transcoding via $command\n";

--- a/updatedb.php
+++ b/updatedb.php
@@ -139,7 +139,6 @@
 				} elseif(isset($photoExtensions[strtolower(getext($fn))]) && $path != '') {
 					$photos[$path][] = $fn;
 				} elseif(isset($videoExtensions[strtolower(getext($fn))]) && $path != '') {
-					echo 'found video: '.$subpath."\n";
 					$videos[$path][] = $fn;
 				}
 			}

--- a/updatedb.php
+++ b/updatedb.php
@@ -31,7 +31,7 @@
 	// insert new albums
 	foreach($albums as $path=>$dirs) {
 		foreach($dirs as $album) {
-			if(isset($photos[$path . $album .'/']) || isset($albums[$path . $album .'/'])) {
+			if(isset($photos[$path . $album .'/']) || isset($videos[$path . $album .'/']) || isset($albums[$path . $album .'/'])) {
 				sql_query("INSERT INTO fa_albums (name, path) VALUES (%s, %s)", $album, $path);
 			}
 		}

--- a/updatedb.php
+++ b/updatedb.php
@@ -1,11 +1,14 @@
 <?php
 	$cli_mode = true;
 	require('header.php');
+	require('dbutils.php');
 
 	/* This script updates the database with photos in the $fotodir
 	   It sets old albums/photos to lost, sets re-found albums/photos to hidden
 	   and inserts new albums/photos with visibility hidden.
 	 */
+
+	$lock = lock_db();
 
 	$albums = array();
 	$photos = array();
@@ -114,6 +117,8 @@
 				die (mysql_error());
 		}
 	}
+
+	unlock_db($lock);
 
 	require('footer.php');
 

--- a/updatedb.php
+++ b/updatedb.php
@@ -38,7 +38,7 @@
 	}
 
 	// check each photo
-	$res = sql_query('SELECT name, path, visibility FROM fa_photos');
+	$res = sql_query('SELECT name, path, visibility FROM fa_photos where type="photo"');
 	while($row = mysql_fetch_assoc($res)) {
 		// if the photo in the db isn't in $fotodir anymore, set it to lost
 		if(!isset($photos[$row['path']]) || !in_array($row['name'], $photos[$row['path']])) {
@@ -78,8 +78,9 @@
 			if (!sql_query("INSERT INTO fa_photos (
 					name,
 					path,
-					rotation)
-				VALUES (%s, %s, %i)",
+					rotation,
+					type)
+				VALUES (%s, %s, %i, 'photo')",
 					$photo, $path, $or))
 				die (mysql_error());
 		}
@@ -87,15 +88,15 @@
 
 
 	// check each video
-	$res = sql_query('SELECT name, path, visibility FROM fa_videos');
+	$res = sql_query('SELECT name, path, visibility FROM fa_photos where type="video"');
 	while($row = mysql_fetch_assoc($res)) {
 		// if the photo in the db isn't in $fotodir anymore, set it to lost
 		if(!isset($videos[$row['path']]) || !in_array($row['name'], $videos[$row['path']])) {
-			sql_query("UPDATE fa_videos SET visibility='lost' WHERE name=%s AND path=%s", $row['name'], $row['path']);
+			sql_query("UPDATE fa_photos SET visibility='lost' WHERE name=%s AND path=%s", $row['name'], $row['path']);
 		} else {
 			unset($videos[$row['path']][array_search($row['name'], $videos[$row['path']])]);
 			if($row['visibility'] == 'lost') {
-				sql_query("UPDATE fa_videos SET visibility='hidden' WHERE name=%s AND path=%s", $row['name'], $row['path']);
+				sql_query("UPDATE fa_photos SET visibility='hidden' WHERE name=%s AND path=%s", $row['name'], $row['path']);
 			}
 		}
 	}
@@ -104,10 +105,11 @@
 	// insert remaining videos
 	foreach($videos as $path=>$dirs) {
 		foreach($dirs as $video) {
-			if (!sql_query("INSERT INTO fa_videos (
+			if (!sql_query("INSERT INTO fa_photos (
 					name,
-					path)
-				VALUES (%s, %s)",
+					path,
+					type)
+				VALUES (%s, %s, 'video')",
 					$video, $path))
 				die (mysql_error());
 		}

--- a/updatedb.php
+++ b/updatedb.php
@@ -8,6 +8,7 @@
 	   and inserts new albums/photos with visibility hidden.
 	 */
 
+	// warning: when not run from the CLI, the lock may remain in case of errors.
 	$lock = lock_db();
 
 	$albums = array();

--- a/view.php
+++ b/view.php
@@ -27,6 +27,7 @@
 	}
 
 	$name = $photo['name'];
+	$type = $photo['type'];
 	$foto = $photo['path'] . $photo['name'];
 	$album = $photo['path'];
 	$id = $photo['id'];
@@ -73,6 +74,7 @@
 	template_assign('mode');
 
 	template_assign('name');
+	template_assign('type');
 	template_assign('album');
 	template_assign('parentalbums');
 	template_assign('foto');


### PR DESCRIPTION
Fix voor issue #26. Mogelijkheid om video's in het fotoboek toe te voegen.
Dit zorgt ervoor dat video's netjes afgehandeld worden, op (vrijwel) dezelfde manier als afbeeldingen.
# Extra vereisten:
- Hiervoor is een wijziging in de tabel nodig, zie de wijzigingen in https://github.com/karpenoktem/knfotos/blob/master/SQL.
  - fa_photos.cache: extra set values `'360p'`, `'720p'`
  - extra kolom in fa_photos: ``type` enum('photo','video') NOT NULL default 'photo'`
- Een recente versie van ffmepg moet geïnstalleerd zijn. Zelf heb ik ffmpeg van source gecompileerd.
- X-Sendfile moet ingeschakeld worden om video streamen te laten werken.

Dat was het volgens mij.

Wat het oplevert:
- Video's in mp4 en webm, zodat alle moderne browsers via html5 video worden ondersteund.
- Video's in lage (360p) en hoge (720p, HD) resolutie.

(potentiële) issues:
- IE8 en lager worden niet ondersteund. Als alternatief is er een downloadlink beschikbaar. Eventueel kan een flash applet gebruikt worden, maar dat moet dan nog ingebouwd worden.
- transcoden kan vrij lang duren (alhoewel, die servers zijn vrij vlot voor zover ik heb gezien, dus dat is niet echt een issue).
- 720p is misschien wel erg groot. Deze kan te breed worden voor een gemiddeld beeldscherm.
- Nog niks is te configureren. Dit wil ik nog toevoegen.
- Verder heb ik nog niks gezien.

Wat vinden jullie er van?
